### PR TITLE
Argument 3 must be of type array or null

### DIFF
--- a/classes/task/cleanup_oidc_state_and_token.php
+++ b/classes/task/cleanup_oidc_state_and_token.php
@@ -44,7 +44,7 @@ class cleanup_oidc_state_and_token extends scheduled_task {
         global $DB;
 
         // Clean up oidc state.
-        $DB->delete_records_select('auth_oidc_state', 'timecreated < ?', strtotime('-5 min'));
+        $DB->delete_records_select('auth_oidc_state', 'timecreated < ?', array(strtotime('-5 min')));
 
         // Clean up invalid oidc token.
         $DB->delete_records('auth_oidc_token', ['userid' => 0]);


### PR DESCRIPTION
Fixed failing cron task. Argument 3 must be of type array or null, int given.
See: https://docs.moodle.org/dev/Data_manipulation_API#delete_records_select
