### PR TITLE
Fix signature mismatch in getauthrequestparams method

### DIFF
--- a/classes/tests/mockoidcclient.php
+++ b/classes/tests/mockoidcclient.php
@@ -45,7 +45,8 @@ class mockoidcclient extends \auth_oidc\oidcclient {
      * @param array $extraparams Additional parameters to send with the OIDC request.
      * @return array Array of request parameters.
      */
-    public function getauthrequestparams($promptlogin = false, array $stateparams = array(), array $extraparams = array()) {
+    public function getauthrequestparams($promptlogin = false, array $stateparams = array(),
+     array $extraparams = array(), bool $selectaccount = false) {
         return parent::getauthrequestparams($promptlogin, $stateparams);
     }
 }


### PR DESCRIPTION
Updated the `getauthrequestparams` method in `mockoidcclient` to match the signature of the parent `oidcclient` class. Added the missing `$selectaccount` parameter.