### PR TITLE
OS-1684: no namespace for moodle_url()

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -47,7 +47,7 @@ class hook_callbacks {
 
                 // Set the return URL.
                 if ($url = qualified_me()) {
-                    $wantsurl = new moodle_url($url);
+                    $wantsurl = new \moodle_url($url);
                     $wantsurl->remove_params('oidc');
                     $SESSION->wantsurl = $wantsurl->out(false);
                 }


### PR DESCRIPTION
To fix this bug:
![image](https://github.com/user-attachments/assets/171bbd0a-cdc2-4328-ba40-0386904b7b14)
