### PR TITLE
Fix privacy provider: Add missing coverage for auth_oidc_sid

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -130,7 +130,7 @@ class auth_plugin_oidc extends \auth_plugin_base {
             $oidc = 0;
         }
         if (!$this->config->forceredirect) {
-            return false; // Never redirect if we haven't enabled the forceredirect setting
+            return false; // Never redirect if we haven't enabled the forceredirect setting.
         }
         // Never redirect on POST.
         if (isset($_SERVER['REQUEST_METHOD']) && ($_SERVER['REQUEST_METHOD'] == 'POST')) {

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -76,6 +76,10 @@ class provider implements
                 'refreshtoken',
                 'idtoken',
             ],
+            'auth_oidc_sid' => [
+                'userid',
+                'sid',
+            ],
         ];
 
         foreach ($tables as $table => $fields) {
@@ -116,6 +120,13 @@ class provider implements
         $params = ['userid' => $userid, 'contextlevel' => CONTEXT_USER];
         $contextlist->add_from_sql($sql, $params);
 
+        $sql = "SELECT ctx.id
+                  FROM {auth_oidc_sid} s
+                  JOIN {context} ctx ON ctx.instanceid = s.userid AND ctx.contextlevel = :contextlevel
+                 WHERE s.userid = :userid";
+        $params = ['userid' => $userid, 'contextlevel' => CONTEXT_USER];
+        $contextlist->add_from_sql($sql, $params);
+
         return $contextlist;
     }
 
@@ -148,6 +159,14 @@ class provider implements
                   FROM {auth_oidc_token} tk
                   JOIN {context} ctx
                        ON ctx.instanceid = tk.userid
+                       AND ctx.contextlevel = :contextuser
+                 WHERE ctx.id = :contextid";
+        $userlist->add_from_sql('userid', $sql, $params);
+
+        $sql = "SELECT ctx.instanceid as userid
+                  FROM {auth_oidc_sid} s
+                  JOIN {context} ctx
+                       ON ctx.instanceid = s.userid
                        AND ctx.contextlevel = :contextuser
                  WHERE ctx.id = :contextid";
         $userlist->add_from_sql('userid', $sql, $params);
@@ -184,6 +203,7 @@ class provider implements
         $tables = [
             'auth_oidc_prevlogin' => ['userid' => $user->id],
             'auth_oidc_token' => ['userid' => $user->id],
+            'auth_oidc_sid' => ['userid' => $user->id],
         ];
         return $tables;
     }
@@ -224,6 +244,7 @@ class provider implements
         global $DB;
         $DB->delete_records('auth_oidc_prevlogin', ['userid' => $userid]);
         $DB->delete_records('auth_oidc_token', ['userid' => $userid]);
+        $DB->delete_records('auth_oidc_sid', ['userid' => $userid]);
     }
 
     /**

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -30,5 +30,5 @@ $callbacks = [
         'hook' => \core\hook\after_config::class,
         'callback' => \auth_oidc\hook_callbacks::class . '::after_config',
         'priority' => 0,
-    ]
+    ],
 ];

--- a/lang/en/auth_oidc.php
+++ b/lang/en/auth_oidc.php
@@ -302,6 +302,9 @@ $string['privacy:metadata:auth_oidc_token:token'] = 'The token';
 $string['privacy:metadata:auth_oidc_token:expiry'] = 'The token expiry';
 $string['privacy:metadata:auth_oidc_token:refreshtoken'] = 'The refresh token';
 $string['privacy:metadata:auth_oidc_token:idtoken'] = 'The ID token';
+$string['privacy:metadata:auth_oidc_sid'] = 'The sid values';
+$string['privacy:metadata:auth_oidc_sid:userid'] = 'The user ID of the Moodle user';
+$string['privacy:metadata:auth_oidc_sid:sid'] = 'The sid';
 
 // In the following strings, $a refers to a customizable name for the identity manager. For example, this could be
 // "Microsoft 365", "OpenID Connect", etc.

--- a/tests/oidcclient_test.php
+++ b/tests/oidcclient_test.php
@@ -111,8 +111,6 @@ final class oidcclient_test extends \advanced_testcase {
     /**
      * Test setting and getting endpoints.
      *
-     * @param $endpoints
-     * @param $expectedexception
      * @dataProvider dataprovider_endpoints
      * @covers \auth_oidc\tests\mockoidcclient::setendpoints
      * @param array $endpoints


### PR DESCRIPTION
01 
```
1) core_privacy\privacy\provider_test::test_table_coverage
The following tables with user fields must be covered with metadata providers: 
  - auth_oidc_sid (userid)

/var/www/site/privacy/tests/privacy/provider_test.php:328
/var/www/site/lib/phpunit/classes/advanced_testcase.php:76
```

02 
```
 FILE: /home/runner/work/moodle-auth_oidc/moodle-auth_oidc/moodle/auth/oidc/auth.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 133 | WARNING | Inline comments must end in full-stops, exclamation marks, or question marks
     |         | (moodle.Commenting.InlineComment.InvalidEndChar)
------------------------------------------------------------------------------------------------------------------------------------

FILE: /home/runner/work/moodle-auth_oidc/moodle-auth_oidc/moodle/auth/oidc/db/hooks.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 33 | ERROR | [x] There should be a comma after the last array item in a multi-line array.
    |       |     (NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine)
------------------------------------------------------------------------------------------------------------------------------------
```

03 

`Line 114: Phpdocs for function oidcclient_test::test_endpoints_getters_and_setters has incomplete parameters list (error)`